### PR TITLE
Ability to Restrict Default Color Palette

### DIFF
--- a/config/bard-custom-colors.php
+++ b/config/bard-custom-colors.php
@@ -20,10 +20,11 @@ return [
     |
     */
 
+    /*
     'custom_colors' => [
-        'pechet-light-blue' => '#b8d4d4',
-        'pechet-dark-blue' => '#519098',
+        'drunken-penguin' => '#F5F3EF',
     ],
+    */
 
     /*
     |--------------------------------------------------------------------------
@@ -46,8 +47,10 @@ return [
     |
     */
 
+    /*
     'default_colors' => [
         'black' => '#000000',
         'white' => '#FFFFFF',
     ],
+    */
 ];

--- a/config/bard-custom-colors.php
+++ b/config/bard-custom-colors.php
@@ -1,16 +1,53 @@
-<?php 
-  /*
-   * An array of custom colors.
-   * Declare them like this:
-   * 'drunken-penguin' => '#F5F3EF'
-   * You can also have colors declared like this
-   * 'red' => [
-   *    '100' => '#fff5f5',
-   *    '200' => '#fed7d7',
-   *    ...
-   *    '900' => '#7b341e',
-   *    ]
-   */
+<?php
+
 return [
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Bard Custom Colors
+    |--------------------------------------------------------------------------
+    |
+    | Declare them like this:
+    | 'drunken-penguin' => '#F5F3EF'
+    |
+    | You can also have colors declared like this:
+    | 'red' => [
+    |   '100' => '#fff5f5',
+    |   '200' => '#fed7d7',
+    |   ...
+    |   '900' => '#7b341e',
+    | ]
+    |
+    */
+
+    'custom_colors' => [
+        'pechet-light-blue' => '#b8d4d4',
+        'pechet-dark-blue' => '#519098',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bard Default Colors
+    |--------------------------------------------------------------------------
+    |
+    | This allows you to restrict what colors appear in the default colors section.
+    | If left blank, this will be pulled from the Tailwind defaults.
+    |
+    | Declare them like this:
+    | 'drunken-penguin' => '#F5F3EF'
+    |
+    | You can also have colors declared like this:
+    | 'red' => [
+    |   '100' => '#fff5f5',
+    |   '200' => '#fed7d7',
+    |   ...
+    |   '900' => '#7b341e',
+    | ]
+    |
+    */
+
+    'default_colors' => [
+        'black' => '#000000',
+        'white' => '#FFFFFF',
+    ],
 ];
-?>

--- a/dist/js/textcolor.js
+++ b/dist/js/textcolor.js
@@ -6693,10 +6693,14 @@ __webpack_require__.r(__webpack_exports__);
 
 
 Statamic.booting(function () {
-  var defaultColors = Statamic.$config.get('bard-default-colors') || null;
   var customColors = Statamic.$config.get('bard-custom-colors') || null;
-  window.bardDefaultColors = defaultColors;
+  var defaultColors = Statamic.$config.get('bard-default-colors') || null;
+  if (defaultColors && defaultColors.length === 0) {
+    defaultColors = null;
+  }
+
   window.bardCustomColors = customColors;
+  window.bardDefaultColors = defaultColors;
   Statamic.$bard.extend(function (_ref) {
     var mark = _ref.mark;
     return mark(new _TextColor__WEBPACK_IMPORTED_MODULE_0__["default"]());

--- a/dist/js/textcolor.js
+++ b/dist/js/textcolor.js
@@ -167,7 +167,7 @@ var defaultTheme = __webpack_require__(/*! tailwindcss/defaultTheme */ "./node_m
   data: function data() {
     return {
       showColorMenu: false,
-      availableColors: defaultTheme.colors,
+      availableColors: null,
       availableCustomColors: null,
       selectedColors: defaultTheme.colors,
       selectedGroup: 'default',
@@ -197,6 +197,7 @@ var defaultTheme = __webpack_require__(/*! tailwindcss/defaultTheme */ "./node_m
   },
   mounted: function mounted() {
     this.availableCustomColors = window.bardCustomColors ? window.bardCustomColors : null;
+    this.availableColors = window.bardDefaultColors ? window.bardDefaultColors : defaultTheme.colors;
   },
   created: function created() {}
 });
@@ -6692,7 +6693,9 @@ __webpack_require__.r(__webpack_exports__);
 
 
 Statamic.booting(function () {
+  var defaultColors = Statamic.$config.get('bard-default-colors') || null;
   var customColors = Statamic.$config.get('bard-custom-colors') || null;
+  window.bardDefaultColors = defaultColors;
   window.bardCustomColors = customColors;
   Statamic.$bard.extend(function (_ref) {
     var mark = _ref.mark;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,7 +21,8 @@ class ServiceProvider extends AddonServiceProvider
 
         Augmentor::addMark(TextColor::class);
         Statamic::provideToScript([
-            'bard-custom-colors' => config('bard-custom-colors'),
+            'bard-custom-colors' => config('bard-custom-colors.custom_colors', config('bard-custom-colors')),
+            'bard-default-colors' => config('bard-custom-colors.default_colors'),
         ]);
     }
 }


### PR DESCRIPTION
This pull request adds functionality to allow the user to restrict the list of colors in the default palette. In my use case, I have a restricted color palette and don't want my Statamic users to be able to pick invalid colors. This is also helpful for people who are purging unused Tailwind styles in production.

This PR is backwards compatible with the old style config, so it is not a breaking change.